### PR TITLE
Correct figure inclusion into text

### DIFF
--- a/ditaa.sty
+++ b/ditaa.sty
@@ -28,7 +28,7 @@
         \VerbatimOut{\ditaafile}}
     {\endVerbatimOut
         \immediate\write18{ditaa -E "\ditaafile" "\ditaadir/\ditaastem.png"}
-        \begin{figure}[ht]
+        \begin{figure}[H]
             \begin{center}
                 \vspace{-1em}
                 \includegraphics[width=\ditaafigwidth]{\ditaadir/\ditaastem.png}


### PR DESCRIPTION
The [H] force the figure to stay where it is declared into the flow of text. Useful if you have several figures into the same page.